### PR TITLE
Remove unnecessary tags

### DIFF
--- a/Lab/Exercise1/01-Start/ContosoExpenses/ContosoExpenses/ExpenseDetail.xaml
+++ b/Lab/Exercise1/01-Start/ContosoExpenses/ContosoExpenses/ExpenseDetail.xaml
@@ -38,9 +38,6 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
-                <RowDefinition Height="*"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
             <TextBlock FontSize="24" Text="Expense" Grid.Row="0" />


### PR DESCRIPTION
This is related to #24.
I removed unnecessary tags at Exercise1/01-Start/ContosoExpenses/ContosoExpenses/ExpenseDetail.xaml.

The under the Grid.RowDefinitions looks like be already completed until Exercise 2.